### PR TITLE
core: allow for implicit setup of the cache app

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ You can add a http_redirect to automatically redirect `http` -> `https` like sho
 ```
 {
   order ja3 before respond # change this to whatever idk
-  ja3
   servers {
      listener_wrappers {
        http_redirect

--- a/cache.go
+++ b/cache.go
@@ -4,9 +4,6 @@ import (
 	"sync"
 
 	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/dreadl0ck/ja3"
 	"github.com/dreadl0ck/tlsx"
 )
@@ -17,22 +14,16 @@ const (
 
 func init() {
 	caddy.RegisterModule(Cache{})
-	httpcaddyfile.RegisterGlobalOption("ja3", func(d *caddyfile.Dispenser, existingVal any) (any, error) {
-		app := &Cache{
-			ja3:     make(map[string]string),
-			ja3Lock: sync.RWMutex{},
-		}
-
-		return httpcaddyfile.App{
-			Name:  CacheAppId,
-			Value: caddyconfig.JSON(app, nil),
-		}, nil
-	})
 }
 
 type Cache struct {
 	ja3     map[string]string
 	ja3Lock sync.RWMutex
+}
+
+func (c *Cache) Provision(ctx caddy.Context) error {
+	c.ja3 = make(map[string]string)
+	return nil
 }
 
 func (c *Cache) SetClientHello(addr string, ch []byte) error {
@@ -90,5 +81,6 @@ func (c *Cache) Stop() error {
 
 // Interface guards
 var (
-	_ caddy.App = (*Cache)(nil)
+	_ caddy.App         = (*Cache)(nil)
+	_ caddy.Provisioner = (*Cache)(nil)
 )

--- a/handler.go
+++ b/handler.go
@@ -1,7 +1,6 @@
 package caddy_ja3
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/caddyserver/caddy/v2"
@@ -33,9 +32,6 @@ func (JA3Handler) CaddyModule() caddy.ModuleInfo {
 
 // Provision implements caddy.Provisioner
 func (h *JA3Handler) Provision(ctx caddy.Context) error {
-	if !ctx.AppIsConfigured(CacheAppId) {
-		return errors.New("global cache is not configured")
-	}
 	a, err := ctx.App(CacheAppId)
 	if err != nil {
 		return err

--- a/listener.go
+++ b/listener.go
@@ -35,9 +35,6 @@ func (JA3Listener) CaddyModule() caddy.ModuleInfo {
 }
 
 func (l *JA3Listener) Provision(ctx caddy.Context) error {
-	if !ctx.AppIsConfigured(CacheAppId) {
-		return errors.New("global cache is not configured")
-	}
 	a, err := ctx.App(CacheAppId)
 	if err != nil {
 		return err


### PR DESCRIPTION
Calling `ctx.App()` will implicitly load and provision the cache app if not already done. The `Provision` method is added to instantiate the map to avoid encountering nil maps. This change makes the explicit mention of `ja3` as a global option unnecessary. The cache is created implicitly when the listener or the handler are configured.